### PR TITLE
Allow Contributors management by core contirbutors

### DIFF
--- a/config/seeds.js
+++ b/config/seeds.js
@@ -1,10 +1,12 @@
 let contractCalls = {
-  Operator: {
+  Contributors: {
     addContributor: [
       // make sure to use an IPFS hash of one of the objects in ipfsContent
       ['0x24dd2aedd8a9fe52ac071b3a23b2fc8f225c185e', '0x272bbfc66166f26cae9c9b96b7f9590e095f02edf342ac2dd71e1667a12116ca', 18, 32, true], // QmQyZJT9uikzDYTZLhhyVZ5ReZVCoMucYzyvDokDJsijhj
       ['0xa502eb4021f3b9ab62f75b57a94e1cfbf81fd827', '0x9569ed44826286597982e40bbdff919c6b7752e29d13250efca452644e6b4b25', 18, 32, true] // QmYPu8zvtfDy18ZqHCviVxnKtxycw5UTJLJyk9oAEjWfnL
-    ],
+    ]
+  },
+  Operator: {
     addProposal: [
       [1, 23, '0x1e1a168d736fc825213144973a8fd5b3cc9f37ad821a8b3d9c3488034bbf69d8', 18, 32], // QmQNA1hhVyL1Vm6HiRxXe9xmc6LUMBDyiNMVgsjThtyevs"
       [2, 42, '0x1e1a168d736fc825213144973a8fd5b3cc9f37ad821a8b3d9c3488034bbf69d8', 18, 32], // QmQNA1hhVyL1Vm6HiRxXe9xmc6LUMBDyiNMVgsjThtyevs"

--- a/scripts/add-contributor.js
+++ b/scripts/add-contributor.js
@@ -30,7 +30,7 @@ module.exports = function(callback) {
     let ipfsHash = process.argv[5] || 'QmQyZJT9uikzDYTZLhhyVZ5ReZVCoMucYzyvDokDJsijhj';
     let contributorMultihash = getBytes32FromMultiash(ipfsHash);
     let isCore = true;
-    let contributorResult = await operator.addContributor(contributorToAddAddress, contributorMultihash.digest, contributorMultihash.hashFunction, contributorMultihash.size, isCore);
+    let contributorResult = await contributors.addContributor(contributorToAddAddress, contributorMultihash.digest, contributorMultihash.hashFunction, contributorMultihash.size, isCore);
     console.log('Contributor added, tx: ', contributorResult.tx);
 
     let contributorId = await contributors.getContributorIdByAddress(contributorToAddAddress);
@@ -39,7 +39,7 @@ module.exports = function(callback) {
     console.log('Proposal added, tx: ', proposalResult.tx);
 
     let proposalId = await operator.proposalsCount();
-    let votingResult = operator.vote(proposalId.toNumber()-1);
+    let votingResult = await operator.vote(proposalId.toNumber()-1);
     console.log('Voted for proposal', proposalId.toString(), votingResult.tx);
 
     callback();


### PR DESCRIPTION
So far we only allowed calls to the Contributors contract from the
Operator. With the new registry concept we can call functions again
directly on the Contributors contract (without the need to call it through
the operator).
This changes the authentication for the contributor management functions
to allow either core contributors or the operator to call them.

In the future I envision a bit more flexible and configurable
authentication concept that can more easily evolve over time.