### PR TITLE
Persist ganache DB and use fixed Mnemonic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 node_modules
+.ganache-db

--- a/README.mdown
+++ b/README.mdown
@@ -22,11 +22,18 @@ We use following solidity contract libraries:
 For local development it is recommended to use [ganache-cli](https://github.com/trufflesuite/ganache-cli) (or the [ganache GUI](http://truffleframework.com/ganache/) to run a local development chain.  
 Using the ganache simulator no full Ethereum node is required.
 
-We default to the port 7545 for development to not get in conflict with the default Ethereum RPC port. Have a look at `ganache-cli` for more configuration options.
+We default to: 
+
+* port 7545 for development to not get in conflict with the default Ethereum RPC port.
+* network ID 100 to stay on the same network id
+* store ganache data in .ganache-db to presist the chain data across restarts
+* use a fixed Mnemonic code to get the same accounts across restarts
+
+Have a look at `ganache-cli` for more configuration options.
 
 Run your ganache simulator before using Kredits locally:
 
-    $ ganache-cli -p 7545
+    $ npm run ganache (which is: ganache-cli -p 7545 -i 100 --db=./.ganache-db -m kredits)
 
 ### Truffle console
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build-json": "truffle compile && node ./scripts/build-json.js",
     "bootstrap": "truffle migrate --reset && truffle exec scripts/seeds.js && npm run build-json",
-    "ganache": "ganache-cli -p 7545 -i 100",
+    "ganache": "ganache-cli -p 7545 -i 100 --db=./.ganache-db -m kredits",
     "dev": "truffle migrate && npm run build-json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This persists the state of the ganache db and uses a fixed mnemonic
code to create accounts.
It now acts more like a local presistent database and no need to
send funds to the accounts after restart.