### PR TITLE
Use prompt instead of argv arguments in scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4230,6 +4230,16 @@
       "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
       "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
     },
+    "promptly": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/promptly/-/promptly-3.0.3.tgz",
+      "integrity": "sha512-EWnzOsxVKUjqKeE6SStH1/cO4+DE44QolaoJ4ojGd9z6pcNkpgfJKr1ncwxrOFHSTIzoudo7jG8y0re30/LO1g==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0",
+        "read": "1.0.7"
+      }
+    },
     "protocol-buffers-schema": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
@@ -4341,6 +4351,15 @@
             "is-buffer": "1.1.6"
           }
         }
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "0.0.7"
       }
     },
     "read-chunk": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/67P/truffle-kredits#readme",
   "devDependencies": {
     "ganache-cli": "^6.0.3",
+    "promptly": "^3.0.3",
     "truffle": "^4.1.3",
     "zeppelin-solidity": "^1.7.0"
   },

--- a/scripts/add-contributor.js
+++ b/scripts/add-contributor.js
@@ -1,8 +1,9 @@
 const Registry = artifacts.require('./Registry.sol');
 const Operator = artifacts.require('./Operator.sol');
 const Contributors = artifacts.require('./Contributors.sol');
+const promptly = require('promptly');
 
-var bs58 = require('bs58');
+const bs58 = require('bs58');
 
 function getBytes32FromMultiash(multihash) {
   const decoded = bs58.decode(multihash);
@@ -22,12 +23,9 @@ module.exports = function(callback) {
     var operator = await Operator.at(operatorAddress);
     var contributors = await Contributors.at(contributorsAddress);
 
-    let contributorToAddAddress = process.argv[4];
-    if(!contributorToAddAddress) {
-      console.log('please provide an address');
-      proxess.exit();
-    }
-    let ipfsHash = process.argv[5] || 'QmQyZJT9uikzDYTZLhhyVZ5ReZVCoMucYzyvDokDJsijhj';
+    let contributorToAddAddress = await promptly.prompt('Contributor address: ');
+    let ipfsHash = await promptly.prompt('IPFS hash (blank for default): ', { default: 'QmQNA1hhVyL1Vm6HiRxXe9xmc6LUMBDyiNMVgsjThtyevs' });
+
     let contributorMultihash = getBytes32FromMultiash(ipfsHash);
     let isCore = true;
     let contributorResult = await contributors.addContributor(contributorToAddAddress, contributorMultihash.digest, contributorMultihash.hashFunction, contributorMultihash.size, isCore);

--- a/scripts/add-proposal.js
+++ b/scripts/add-proposal.js
@@ -1,8 +1,9 @@
 const Registry = artifacts.require('./Registry.sol');
 const Operator = artifacts.require('./Operator.sol');
 const Contributors = artifacts.require('./Contributors.sol');
+const promptly = require('promptly');
 
-var bs58 = require('bs58');
+const bs58 = require('bs58');
 
 function getBytes32FromMultiash(multihash) {
   const decoded = bs58.decode(multihash);
@@ -22,12 +23,9 @@ module.exports = function(callback) {
     var operator = await Operator.at(operatorAddress);
     var contributors = await Contributors.at(contributorsAddress);
 
-    let recipientAddress = process.argv[4];
-    if(!recipientAddress) {
-      console.log('please provide an address');
-      process.exit();
-    }
-    let ipfsHash = process.argv[5] || 'QmQNA1hhVyL1Vm6HiRxXe9xmc6LUMBDyiNMVgsjThtyevs';
+    let recipientAddress = await promptly.prompt('Contributor address: ');
+    let ipfsHash = await promptly.prompt('IPFS hash (blank for default): ', { default: 'QmQNA1hhVyL1Vm6HiRxXe9xmc6LUMBDyiNMVgsjThtyevs' });
+
     let multihash = getBytes32FromMultiash(ipfsHash);
 
     let contributorId = await contributors.getContributorIdByAddress(recipientAddress);

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,17 +1,15 @@
 const REPL = require('repl');
+const promptly = require('promptly');
 
 module.exports = function(callback) {
   const Registry = artifacts.require('./Registry.sol');
   Registry.deployed().then(async (registry) => {
-    let contractName = process.argv[4];
-    let method = process.argv[5];
-    let args = process.argv.slice(6);
-
-    if (!contractName) {
-      console.log("Usage:");
-      console.log("  truffle exec scripts/cli.js <Contract name> <method to call> [<optional> <arguments>]");
-      callback();
-      return;
+    let contractName = await promptly.prompt('Contract Name: ');
+    let method = await promptly.prompt('Function: ');
+    let argumentInput = await promptly.prompt('Arguments (comma separated): ', { default: '' });
+    let args = [];
+    if (argumentInput !== '') {
+      args = argumentInput.split(',').map(a => a.trim());
     }
 
     let contractAddress = await registry.getProxyFor(contractName);

--- a/scripts/multihash.js
+++ b/scripts/multihash.js
@@ -1,4 +1,4 @@
-var bs58 = require('bs58');
+const bs58 = require('bs58');
 
 function getBytes32FromMultiash(multihash) {
   const decoded = bs58.decode(multihash);

--- a/scripts/send-funds.js
+++ b/scripts/send-funds.js
@@ -1,12 +1,12 @@
+const promptly = require('promptly');
 
-module.exports = function(callback) {
-  let recipient = process.argv[4];
-  if (!recipient) {
-    console.log('Please provide a recipient address');
-    process.exit();
-  }
-  let amount = parseInt(process.argv[5]) || 1;
-  console.log(recipient);
+module.exports = async function(callback) {
+  let recipient = await promptly.prompt('Recipient address: ');
+  let amount = await promptly.prompt('Amount: ', {default: '1'});
+  amount = parseInt(amount);
+
+  console.log(`sending ${amount} ETH from ${web3.eth.accounts[0]} to ${recipient}`);
+
   web3.eth.sendTransaction({to: recipient, value: web3.toWei(amount), from: web3.eth.accounts[0]}, console.log);
 
   callback();


### PR DESCRIPTION
This makes it easier to handle truffle arguments which we for example
need to specify the network.
So we ask the user for input instead on using the argv array which might
change.