### PR TITLE
Add support for contract tx call options

### DIFF
--- a/lib/contracts/contributor.js
+++ b/lib/contracts/contributor.js
@@ -34,7 +34,7 @@ class Contributor extends Base {
       });
   }
 
-  add(contributorAttr) {
+  add(contributorAttr, callOptions = {}) {
     let json = ContributorSerializer.serialize(contributorAttr);
     // TODO: validate against schema
 
@@ -49,7 +49,7 @@ class Contributor extends Base {
           contributorAttr.isCore,
         ];
 
-        return this.functions.addContributor(...contributor);
+        return this.functions.addContributor(...contributor, callOptions);
       });
   }
 }

--- a/lib/contracts/operator.js
+++ b/lib/contracts/operator.js
@@ -34,7 +34,7 @@ class Operator extends Base {
       });
   }
 
-  addProposal(proposalAttr) {
+  addProposal(proposalAttr, callOptions = {}) {
     let json = ContributionSerializer.serialize(proposalAttr);
     // TODO: validate against schema
 
@@ -49,7 +49,7 @@ class Operator extends Base {
           ipfsHashAttr.hashSize,
         ];
 
-        return this.functions.addProposal(...proposal);
+        return this.functions.addProposal(...proposal, callOptions);
       });
   }
 }


### PR DESCRIPTION
This allows to provide options like gas price/limit settings for the
state changing contract calls.
These options are simply passed to the ethers contract instance.

We need to provide the gas limit when using the jsonrpc provider.
(ganache failed with revert if not enought gas was provider)