### PR TITLE
Refactor kredits address initialization

### DIFF
--- a/lib/contracts/index.js
+++ b/lib/contracts/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   Contributors: require('./contributor'),
   Operator: require('./operator'),
-  Token: require('./token')
-}
+  Token: require('./token'),
+  Registry: require('./registry')
+};

--- a/lib/contracts/registry.js
+++ b/lib/contracts/registry.js
@@ -1,0 +1,6 @@
+const Base = require('./base');
+
+class Registry extends Base {
+}
+
+module.exports = Registry;

--- a/lib/kredits.js
+++ b/lib/kredits.js
@@ -1,17 +1,15 @@
 const ethers = require('ethers');
 const RSVP = require('rsvp');
 
-const abis = {
+const ABIS = {
   Contributors: require('./abis/Contributors.json'),
   Operator: require('./abis/Operator.json'),
   Registry: require('./abis/Registry.json'),
   Token: require('./abis/Token.json')
 };
-const addresses = {
-  Registry: require('./addresses/Registry.json')
-};
+const RegistryAddress = require('./addresses/Registry.json');
 
-const contracts = require('./contracts');
+const Contracts = require('./contracts');
 const IPFS = require('./utils/ipfs')
 
 // Helpers
@@ -22,64 +20,52 @@ function capitalize(word) {
 
 class Kredits {
   static get contractNames() {
-    return Object.keys(abis);
+    return Object.keys(ABIS);
   }
 
   constructor(provider, signer, addresses) {
     this.provider = provider;
     this.signer = signer;
 
-    // Initialize our registry contract
-    this.addresses = addresses;
+    // by default we only need the registry address.
+    // the rest is loaded from there in the init() function
+    this.addresses = addresses || {Registry: RegistryAddress[this.provider.chainId.toString()]}; // chaiID must be a string
+    this.abis = ABIS;
     this.contracts = {};
     this.ipfs = new IPFS();
   }
 
-  static setup(provider, signer, ipfsConfig = null) {
-    let ipfsAPI = new IPFS(ipfsConfig);
+  init(names) {
+    let contractsToLoad = names || Kredits.contractNames;
+    let addressPromises = contractsToLoad.map((contractName) => {
+      return this.Registry.functions.getProxyFor(contractName).then((address) => {
+        this.addresses[contractName] = address;
+      }).catch((error) => {
+        throw new Error(`Failed to get address for ${contractName} from registry at ${this.Registry.contract.address}
+          - correct registry? does it have version entry? - ${error.message}`
+        );
+      });
+    });
+    return RSVP.all(addressPromises).then(() => { return this });
+  }
 
-    return ipfsAPI._ipfsAPI.id().catch((error) => {
+  static setup(provider, signer, ipfsConfig = null) {
+    console.log('Kredits.setup() is deprecated use new Kredits().init() instead');
+    let ipfs = new IPFS(ipfsConfig);
+
+    return ipfs._ipfsAPI.id().catch((error) => {
       throw new Error(`IPFS node not available; config: ${JSON.stringify(ipfsConfig)} - ${error.message}`);
     }).then(() => {
 
-      let registryContract = this.initRegistryContract(provider);
-
-      let addresses = Kredits.contractNames.reduce((mem, name) => {
-        let contractName = capitalize(name);
-        mem[contractName] = registryContract.functions.getProxyFor(contractName).catch((error) => {
-          throw new Error(`Failed to get address for ${contractName} from registry at ${registryContract.address}
-            - correct registry? does it have version entry? - ${error.message}`
-          );
-        });
-        return mem;
-      }, {});
-
-      return RSVP.hash(addresses)
-        .then((addresses) => {
-          let kredits = new Kredits(provider, signer, addresses);
-          kredits.ipfs = ipfsAPI;
-          return kredits;
-        });
+      return new Kredits(provider, signer).init().then((kredits) => {
+        kredits.ipfs = ipfs;
+        return kredits;
+      });
     });
   }
 
-  static initRegistryContract(provider) {
-    let address = addresses['Registry'][provider.chainId];
-    if (!address) {
-      throw new Error(`Registry address not found; invalid network?
-        requested network: ${provider.chainId}
-        supported networks: ${Object.keys(addresses['Registry'])}
-      `);
-    }
-    provider.getCode(address).then((code) => {
-      // not sure if we always get the same return value of the code is not available
-      // that's why checking if it is < 5 long
-      if (code === '0x00' || code.length < 5) {
-        throw new Error(`Registry not found at ${address} on network ${provider.chainId}`);
-      }
-    });
-    let abi = abis['Registry'];
-    return new ethers.Contract(address, abi, provider);
+  get Registry() {
+    return this.contractFor('registry');
   }
 
   get Contributor() {
@@ -101,13 +87,14 @@ class Kredits {
       return this.contracts[name];
     }
 
-    let contractName = capitalize(name);
-    let address = this.addresses[contractName];
-    if (!address || !abis[contractName]) {
+    const contractName = capitalize(name);
+    const address = this.addresses[contractName];
+    const abi = this.abis[contractName];
+    if (!address || !abi) {
       throw new Error(`Address or ABI not found for ${contractName}`);
     }
-    let contract = new ethers.Contract(address, abis[contractName], this.signer);
-    this.contracts[name] = new contracts[contractName](contract);
+    let contract = new ethers.Contract(address, abi, this.signer);
+    this.contracts[name] = new Contracts[contractName](contract);
     this.contracts[name].ipfs = this.ipfs;
 
     return this.contracts[name];


### PR DESCRIPTION
This moves the Kredits initialization to the instance which allows us to
be more flexible with handling contract addresses.

Example:

var k = new Kredits(provider, signer, {Registry: '0xabc'});
k.init().then((kredits) { ...});

var k = new Kredits(provider, signer, {Contributors: '0xabc'})
k.Contributor.add(...);