### PR TITLE
Add Contributors alias for Contributor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 node_modules
 .ganache-db
+.tm_properties

--- a/lib/kredits.js
+++ b/lib/kredits.js
@@ -63,6 +63,11 @@ class Kredits {
     return this.contractFor('contributors');
   }
 
+  get Contributors() {
+    console.log('Contributors is deprecated use Contributor instead');
+    return this.Contributor;
+  }
+
   get Operator() {
     return this.contractFor('operator');
   }


### PR DESCRIPTION
Because the contract is named `Contributors` we alias to `Contributor` which will become the new contract name if we manage to change it.

Ref: #41 